### PR TITLE
Rwmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F91D Bug Report"
+about: As a User, I want to report a Bug.
+labels: type/bug
+---
+
+## Bug Report
+
+Please answer these questions before submitting your issue. Thanks!
+
+### 1. Minimal reproduce step (Required)
+
+<!-- a step by step guide for reproducing the bug. -->
+
+### 2. What did you expect to see? (Required)
+
+### 3. What did you see instead (Required)
+
+### 4. What is your gstl version? (Required)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F44F Feature Request"
+about: As a user, I want to request a New Feature on the product.
+labels: type/feature-request
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe:**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the feature you'd like:**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered:**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Teachability, Documentation, Adoption, Migration Strategy:**
+<!-- If you can, explain some scenarios how users might use this, situations it would be helpful in. Any API designs, mockups, or diagrams are also helpful. -->

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F600 Ask a Question"
+about: I want to ask a question.
+labels: type/question
+---
+
+## General Question
+
+<!--
+
+Before asking a question, make sure you have:
+
+- Searched existing Stack Overflow questions.
+- Googled your question.
+- Searched open and closed [GitHub issues](https://github.com/antlabs/gstl/issues)
+- Read the documentation:
+  - [gstl Readme](https://github.com/antlabs/gstl/blob/master/README.md)
+
+-->

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,45 @@
+name: Go
+
+on:
+  push:
+  pull_request:
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.19']
+    name: Go ${{ matrix.go }} sample
+
+    steps:
+
+    - name: Set up Go 1.19
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test -v -coverprofile='coverage.out' -covermode=count ./...
+
+    - name: Upload Coverage report
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        file: ./coverage.out

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,9 +32,6 @@ jobs:
             dep ensure
         fi
 
-    - name: Build
-      run: go build -v .
-
     - name: Test
       run: go test -v -coverprofile='coverage.out' -covermode=count ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+cover.cov

--- a/README.md
+++ b/README.md
@@ -152,3 +152,28 @@ m["b"] = "2"
 m["c"] = "3"
 get := mapex.Values(m)
 ```
+## 十一、`rwmap`
+rwmap与sync.Map类似支持并发访问，只解决sync.Map 2个问题.  
+1. 没有Len成员函数  
+2. 以及没有使用泛型语法，有运行才发现类型使用错误的烦恼
+```go
+var m RWMap[string, string] // 声明一个string, string的map
+m.Store("hello", "1") // 保存
+v1, ok1 := m.Load("hello") // 获取值
+v1, ok1 = m.LoadAndDelete("hello") //返回hello对应值，然后删除hello
+Delete("hello") // 删除
+v1, ok1 = m.LoadOrStore("hello", "world")
+
+// 遍历，使用回调函数
+m.Range(func(key, val string) bool {
+	fmt.Printf("k:%s, val:%s\n"i, key, val)
+	return true
+})
+
+// 遍历，迭代器
+for pair := range m.Iter() {
+  fmt.Printf("k:%s, val:%s\n", pair.Key, pair.Val)
+}
+
+m.Len()// 获取长度
+```

--- a/rwmap/rwmap.go
+++ b/rwmap/rwmap.go
@@ -1,0 +1,75 @@
+// apache 2.0 antlabs
+
+package rwmap
+
+import "sync"
+
+type RWMap[K comparable, V any] struct {
+	rw sync.RWMutex
+	m  map[K]V
+}
+
+func (r *RWMap[K, V]) Delete(key K) {
+	r.rw.Lock()
+	delete(r.m, key)
+	r.rw.Unlock()
+}
+
+func (r *RWMap[K, V]) Load(key K) (value any, ok bool) {
+	r.rw.RLock()
+	value, ok = r.m[key]
+	r.rw.RUnlock()
+	return
+
+}
+
+func (r *RWMap[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
+	r.rw.Lock()
+	if r.m == nil {
+		r.m = make(map[K]V)
+	}
+	value, loaded = r.m[key]
+	delete(r.m, key)
+	r.rw.Unlock()
+	return
+}
+
+// 存在返回现有的值，loaded 为true
+// 不存在就保存现在的值，loaded为false
+func (r *RWMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	r.rw.Lock()
+	actual, loaded = r.m[key]
+	if !loaded {
+		actual = value
+		r.m[key] = actual
+	}
+	r.rw.Unlock()
+	return
+}
+
+func (r *RWMap[K, V]) Range(f func(key K, value V) bool) {
+	r.rw.RLock()
+	for k, v := range r.m {
+		if !f(k, v) {
+			break
+		}
+	}
+	r.rw.RUnlock()
+}
+
+// 保存值
+func (r *RWMap[K, V]) Store(key K, value V) {
+	r.rw.Lock()
+	if r.m == nil {
+		r.m = make(map[K]V)
+	}
+	r.rw.Unlock()
+}
+
+// 返回长度
+func (r *RWMap[K, V]) Len() (l int) {
+	r.rw.RLock()
+	l = len(r.m)
+	r.rw.RUnlock()
+	return
+}

--- a/rwmap/rwmap.go
+++ b/rwmap/rwmap.go
@@ -9,13 +9,27 @@ type RWMap[K comparable, V any] struct {
 	m  map[K]V
 }
 
+type Pair[K comparable, V any] struct {
+	Key K
+	Val V
+}
+
+// 通过new函数分配可以指定map的长度
+func New[K comparable, V any](l int) *RWMap[K, V] {
+	return &RWMap[K, V]{
+		m: make(map[K]V, l),
+	}
+}
+
+// 删除
 func (r *RWMap[K, V]) Delete(key K) {
 	r.rw.Lock()
 	delete(r.m, key)
 	r.rw.Unlock()
 }
 
-func (r *RWMap[K, V]) Load(key K) (value any, ok bool) {
+// 加载
+func (r *RWMap[K, V]) Load(key K) (value V, ok bool) {
 	r.rw.RLock()
 	value, ok = r.m[key]
 	r.rw.RUnlock()
@@ -23,10 +37,12 @@ func (r *RWMap[K, V]) Load(key K) (value any, ok bool) {
 
 }
 
+// 获取值，然后并删除
 func (r *RWMap[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
 	r.rw.Lock()
 	if r.m == nil {
-		r.m = make(map[K]V)
+		r.rw.Unlock()
+		return
 	}
 	value, loaded = r.m[key]
 	delete(r.m, key)
@@ -38,6 +54,9 @@ func (r *RWMap[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
 // 不存在就保存现在的值，loaded为false
 func (r *RWMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
 	r.rw.Lock()
+	if r.m == nil {
+		r.m = make(map[K]V)
+	}
 	actual, loaded = r.m[key]
 	if !loaded {
 		actual = value
@@ -57,12 +76,27 @@ func (r *RWMap[K, V]) Range(f func(key K, value V) bool) {
 	r.rw.RUnlock()
 }
 
+func (r *RWMap[K, V]) Iter() <-chan Pair[K, V] {
+	p := make(chan Pair[K, V])
+	go func() {
+		r.rw.RLock()
+		for k, v := range r.m {
+			p <- Pair[K, V]{Key: k, Val: v}
+		}
+		close(p)
+		r.rw.RUnlock()
+
+	}()
+	return p
+}
+
 // 保存值
 func (r *RWMap[K, V]) Store(key K, value V) {
 	r.rw.Lock()
 	if r.m == nil {
 		r.m = make(map[K]V)
 	}
+	r.m[key] = value
 	r.rw.Unlock()
 }
 

--- a/rwmap/rwmap_test.go
+++ b/rwmap/rwmap_test.go
@@ -1,0 +1,158 @@
+package rwmap
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Store And Load
+func Test_StoreAndLoad(t *testing.T) {
+	var m RWMap[string, string]
+	m.Store("hello", "1")
+	m.Store("world", "2")
+	v1, ok1 := m.Load("hello")
+	assert.Equal(t, v1, "1")
+	assert.True(t, ok1)
+
+	v1, ok1 = m.Load("world")
+	assert.Equal(t, v1, "2")
+	assert.True(t, ok1)
+}
+
+// Store And Load
+func Test_StoreDeleteLoad(t *testing.T) {
+	var m RWMap[string, string]
+	m.Store("hello", "1")
+	m.Store("world", "2")
+
+	m.Delete("hello")
+	m.Delete("world")
+
+	v1, ok1 := m.Load("hello")
+	assert.Equal(t, v1, "")
+	assert.False(t, ok1)
+
+	v1, ok1 = m.Load("world")
+	assert.Equal(t, v1, "")
+	assert.False(t, ok1)
+}
+
+func Test_LoadAndDelete(t *testing.T) {
+
+	var m RWMap[string, string]
+	v1, ok1 := m.LoadAndDelete("hello")
+
+	assert.Equal(t, v1, "")
+	assert.False(t, ok1)
+
+	m.Store("hello", "world")
+	v1, ok1 = m.Load("hello")
+
+	assert.Equal(t, v1, "world")
+
+	v1, ok1 = m.LoadAndDelete("hello")
+	assert.Equal(t, v1, "world")
+	assert.True(t, ok1)
+}
+
+func Test_loadOrStore(t *testing.T) {
+	var m RWMap[string, string]
+	var m2 sync.Map
+	v1, ok1 := m.LoadOrStore("hello", "world")
+	v2, ok2 := m2.LoadOrStore("hello", "world")
+
+	assert.Equal(t, ok1, ok2)
+	assert.Equal(t, v1, v2.(string))
+}
+
+func Test_RangeBreak(t *testing.T) {
+	var m RWMap[string, string]
+	m.Store("1", "1")
+	m.Store("2", "2")
+
+	count := 0
+	m.Range(func(key, val string) bool {
+		count++
+		return false
+	})
+
+	assert.Equal(t, count, 1)
+}
+
+func Test_Range(t *testing.T) {
+	var m RWMap[string, string]
+	max := 5
+	keyAll := []string{}
+	valAll := []string{}
+
+	for i := 1; i < max; i++ {
+		key := fmt.Sprintf("%dk", i)
+		val := fmt.Sprintf("%dv", i)
+		keyAll = append(keyAll, key)
+		valAll = append(valAll, val)
+		m.Store(key, val)
+	}
+
+	gotKey := []string{}
+	gotVal := []string{}
+	m.Range(func(key, val string) bool {
+		gotKey = append(gotKey, key)
+		gotVal = append(gotVal, val)
+		return true
+	})
+
+	sort.Strings(gotKey)
+	sort.Strings(gotVal)
+
+	assert.Equal(t, keyAll, gotKey)
+	assert.Equal(t, valAll, gotVal)
+}
+
+func Test_Iter(t *testing.T) {
+	var m RWMap[string, string]
+	max := 5
+	keyAll := []string{}
+	valAll := []string{}
+
+	for i := 1; i < max; i++ {
+		key := fmt.Sprintf("%dk", i)
+		val := fmt.Sprintf("%dv", i)
+		keyAll = append(keyAll, key)
+		valAll = append(valAll, val)
+		m.Store(key, val)
+	}
+
+	gotKey := []string{}
+	gotVal := []string{}
+	for pair := range m.Iter() {
+
+		gotKey = append(gotKey, pair.Key)
+		gotVal = append(gotVal, pair.Val)
+	}
+
+	sort.Strings(gotKey)
+	sort.Strings(gotVal)
+
+	assert.Equal(t, keyAll, gotKey)
+	assert.Equal(t, valAll, gotVal)
+}
+
+func Test_Len(t *testing.T) {
+	var m RWMap[string, string]
+	m.Store("1", "1")
+	m.Store("2", "2")
+	m.Store("3", "3")
+	assert.Equal(t, m.Len(), 3)
+}
+
+func Test_New(t *testing.T) {
+	m := New[string, string](3)
+	m.Store("1", "1")
+	m.Store("2", "2")
+	m.Store("3", "3")
+	assert.Equal(t, m.Len(), 3)
+}


### PR DESCRIPTION
## 十一、`rwmap`
rwmap与sync.Map类似支持并发访问，只解决sync.Map 2个问题.
1. 没有Len成员函数
2. 以及没有使用泛型语法，有运行才发现类型使用错误的烦恼
```go
var m RWMap[string, string] // 声明一个string, string的map
m.Store("hello", "1") // 保存
v1, ok1 := m.Load("hello") // 获取值
v1, ok1 = m.LoadAndDelete("hello") //返回hello对应值，然后删除hello
Delete("hello") // 删除
v1, ok1 = m.LoadOrStore("hello", "world")

// 遍历，使用回调函数
m.Range(func(key, val string) bool {
	fmt.Printf("k:%s, val:%s\n"i, key, val)
	return true
})

// 遍历，迭代器
for pair := range m.Iter() {
  fmt.Printf("k:%s, val:%s\n", pair.Key, pair.Val)
}

m.Len()// 获取长度
```